### PR TITLE
Remove stock PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,0 @@
-<!--
-⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️
-
-👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
--->


### PR DESCRIPTION
The default template has a scary message (see below) warning you not to accidentally
submit your PR against the upstream repo, but our repo is already
configured to default to our own `main` branch as the target.

> ⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️
> 
> 👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
